### PR TITLE
Set setup long desc type to MD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ def run_setup():
         version=protool.__version__,
         description='A tool for dealing with provisioning profiles',
         long_description=long_description,
+        long_description_content_type="text/markdown",
         url='https://github.com/Microsoft/protool',
         author='Dale Myers',
         author_email='dalemy@microsoft.com',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def run_setup():
         version=protool.__version__,
         description='A tool for dealing with provisioning profiles',
         long_description=long_description,
-        long_description_content_type="text/markdown",
+        long_description_content_type='text/markdown',
         url='https://github.com/Microsoft/protool',
         author='Dale Myers',
         author_email='dalemy@microsoft.com',


### PR DESCRIPTION
The long description on PyPi is currently not set to markdown. This should fix it at the next release.