### PR TITLE
Open README with utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import codecs
 from os import path
 
 from setuptools import setup, find_packages
@@ -12,7 +13,7 @@ def run_setup():
 
     # Get the long description from the README file
     try:
-        with open(path.join(here, 'README.md')) as f:
+        with codecs.open(path.join(here, 'README.md'), encoding='utf-8') as f:
             long_description = f.read()
     except:
         # This happens when running tests


### PR DESCRIPTION
This fix prevents the crash during the installation on machines with non-standard locales.
And it makes consistent among other Microsoft projects, for example https://github.com/Microsoft/jupyter-Kqlmagic/blob/master/setup.py