### PR TITLE
Adding convenience method to get all installed profiles.

### DIFF
--- a/protool/__init__.py
+++ b/protool/__init__.py
@@ -62,6 +62,28 @@ class ProvisioningProfile(object):
         self._contents = plistlib.loads(self.xml.encode())
 
 
+def profiles(profiles_dir = None):
+    """Returns a list of all currently installed provisioning profiles."""
+    if profiles_dir:
+        dir_path = os.path.expanduser(profiles_dir)
+    else:
+        user_path = os.path.expanduser('~')
+        dir_path = os.path.join(user_path, 
+                                "Library", 
+                                "MobileDevice", 
+                                "Provisioning Profiles")
+        
+    profiles = []
+    for profile in os.listdir(dir_path):
+        full_path = os.path.join(dir_path, profile)
+        _, ext = os.path.splitext(full_path)
+        if ext == ".mobileprovision":
+            provisioning_profile = ProvisioningProfile(full_path)
+            profiles.append(provisioning_profile)
+
+    return profiles
+
+
 def diff(a_path, b_path, ignore_keys=None, tool_override=None):
     """Diff two provisioning profiles."""
 


### PR DESCRIPTION
I thought it would be useful to have a convenience function for returning all the provisioning profiles currently installed on the machine. I'm currently writing a lot of code to search through all provisioning profiles installed on the machine, and such a thing would be useful to me. Many other python provisioning profile libraries have some variation of this feature, so I'm sure other people might find this useful as well.