### PR TITLE
Adding Provisioning Profile Types

### DIFF
--- a/protool/__init__.py
+++ b/protool/__init__.py
@@ -2,6 +2,8 @@
 
 """A utility for dealing with provisioning profiles"""
 
+from enum import Enum
+
 import copy
 import os
 import plistlib
@@ -11,6 +13,14 @@ import sys
 import tempfile
 
 __version__ = '0.7'
+
+
+class ProvisioningType(Enum):
+    """Enum representing the type of provisioning profile."""
+    IOS_DEVELOPMENT = 1
+    APP_STORE_DISTRIBUTION = 3
+    AD_HOC_DISTRIBUTION = 5
+    ENTERPRISE_DISTRIBUTION = 7
 
 
 class ProvisioningProfile(object):
@@ -29,6 +39,17 @@ class ProvisioningProfile(object):
         """Return a copy of the content dict."""
         return copy.deepcopy(self._contents)
 
+    @property
+    def profile_type(self):
+        if self.provisions_all_devices:
+            return ProvisioningType.ENTERPRISE_DISTRIBUTION
+        elif not self.entitlements.get("get-task-allow") and self.provisioned_devices:
+            return ProvisioningType.AD_HOC_DISTRIBUTION
+        elif not self.entitlements.get("get-task-allow") and not self.provisioned_devices:
+            return ProvisioningType.APP_STORE_DISTRIBUTION
+        elif self.entitlements.get("get-task-allow") and self.provisioned_devices:
+            return ProvisioningType.IOS_DEVELOPMENT
+
     def _parse_contents(self):
         """Parse the contents of the profile."""
         self.app_id_name = self._contents.get("AppIDName")
@@ -44,6 +65,8 @@ class ProvisioningProfile(object):
         self.time_to_live = self._contents.get("TimeToLive")
         self.uuid = self._contents.get("UUID")
         self.version = self._contents.get("Version")
+        self.provisioned_devices = self._contents.get("ProvisionedDevices")
+        self.provisions_all_devices = True if self._contents.get("ProvisionsAllDevices") else False
 
     def _load_xml(self):
         """Load the XML contents of a provisioning profile."""


### PR DESCRIPTION
Adds a profile_type property that indicates what kind of provisioning profile it is (ios development, ad-hoc, app store, in-house, etc)
