### PR TITLE
Refactoring to add a Certificate object with sha1/X509 support.

### DIFF
--- a/protool/__init__.py
+++ b/protool/__init__.py
@@ -65,16 +65,10 @@ class ProvisioningProfile:
 
         raise Exception("Unable to determine provisioning profile type")
 
-    @property
     def developer_certificates(self) -> List[OpenSSL.crypto.X509]:
         """Returns developer certificates as a list of PyOpenSSL X509."""
         dev_certs: List[OpenSSL.crypto.X509] = []
-        raw_cert_items: List[str] = cast(List[str], self._contents.get("DeveloperCertificates"))
-
-        try:
-            iter(raw_cert_items)
-        except TypeError as _:
-            return []
+        raw_cert_items: List[str] = cast(List[str], self._contents.get("DeveloperCertificates", []))
 
         for cert_item in raw_cert_items:
             loaded_cert: OpenSSL.crypto.X509 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ protool = 'protool:command_line.run'
 
 [tool.poetry.dependencies]
 python = "^3.6"
+pyOpenSSL ="^19.0.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "=0.670"


### PR DESCRIPTION
Refactors the developer_certificates attribute into a property that returns a list of custom Certificate objects, which in turn wrap PyOpenSSL's X509 objects.

Design choices:

* Separate certificates objects had to be made anyways to add any kind of certificate functionality cleanly (I currently need to get certificate SHA-1's for my application).

* The use of PyOpenSSL adds existing crypto function without having to resort to spawning subprocesses to Apple's security tool. 

* The x509 objects are wrapped in separate objects to reduce coupling and not break existing code if PyOpenSSL was ever deprecated and another Python crypto implementation had to be used instead.
