### PR TITLE
WIP Add command to search by app bundle id and provisioning profile type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Alternatively, from the command line:
     # Get the raw XML (identical to using `security cms -D -i /path/to/profile`)
     protool decode --profile /path/to/profile
 
+    # Get the file paths of all .mobileprovision files on the machine with a bundle id that start 
+    # with com.microsoft and that represent ios development provisioning files
+    protool search --appid com.microsoft.* --type ios-dev
+
+
 
 # Contributing
 


### PR DESCRIPTION
It would be useful to have a cli command for searching for provisioning profiles files that partially or fully matching a given app bundle id, as well as to be able to optionally filter those search results by provisioning profile type (ios developer, ad hoc, enterprise, etc). At this point this is more of a proposal for adding the search functionality in general than an actual pull request.